### PR TITLE
Keep CHARTS_URL when gh page using docs foler

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -61,7 +61,7 @@ main() {
       CHARTS_URL="https://${OWNER}.github.io/${REPOSITORY}"
   fi
 
-  if [[ "$TARGET_DIR" != "." ]]; then
+  if [[ "$TARGET_DIR" != "." && "$TARGET_DIR" != "docs" ]]; then
     CHARTS_URL="${CHARTS_URL}/${TARGET_DIR}"
   fi
 


### PR DESCRIPTION
If github page was created using master branch /docs folder, 
- $TARGET_DIR should be specified 
- but the $CHARTS_URL should be https://${OWNER}.github.io/${REPOSITORY}

Fix #16 