### PR TITLE
#issue-19: add ability to define version and app-version of created helm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Inputs:
 * `linting` Toggle Helm linting, can be disabled by setting it to `off`
 * `commit_username` Explicitly specify username for commit back, default to `GITHUB_ACTOR`
 * `commit_email` Explicitly specify email for commit back, default to `GITHUB_ACTOR@users.noreply.github.com`
+* `app_version` Explicitly specify app version in package. If not defined then used chart values.
+* `chart_version` Explicitly specify chart version in package. If not defined then used chart values.
 
 ## Examples
 
@@ -63,4 +65,23 @@ jobs:
           target_dir: charts
           commit_username: johndoe
           commit_email: johndoe@example.com
+```
+Package chart with specified chart & app versions and push all charts in `./charts` dir to `gh-pages` branch:
+```yaml
+name: release
+on:
+  push:
+    tags: '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          app_version: 1.16.0
+          chart_version: 0.1.0
 ```

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,12 @@ inputs:
     description: "The email used for the commit user"
     required: false
     default: ${{ github.actor }}@users.noreply.github.com
+  app_version:
+    description: "Set the appVersion on the chart to this version"
+    required: false
+  chart_version:
+    description: "Set the version on the chart to this version"
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -55,3 +61,5 @@ runs:
     - ${{ inputs.linting }}
     - ${{ inputs.commit_username }}
     - ${{ inputs.commit_email }}
+    - ${{ inputs.app_version }}
+    - ${{ inputs.chart_version }}

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -28,6 +28,8 @@ HELM_VERSION=$8
 LINTING=$9
 COMMIT_USERNAME=${10}
 COMMIT_EMAIL=${11}
+APP_VERSION=${12}
+CHART_VERSION=${13}
 
 CHARTS=()
 CHARTS_TMP_DIR=$(mktemp -d)
@@ -123,7 +125,10 @@ lint() {
 }
 
 package() {
-  helm package ${CHARTS[*]} --destination ${CHARTS_TMP_DIR}
+  [[ -z $APP_VERSION ]] || APP_VERSION_CMD=" --app-version $APP_VERSION";
+  [[ -z $CHART_VERSION ]] || CHART_VERSION_CMD=" --version $CHART_VERSION"
+
+  helm package ${CHARTS[*]} --destination ${CHARTS_TMP_DIR} "$APP_VERSION_CMD" "$CHART_VERSION_CMD"
 }
 
 upload() {


### PR DESCRIPTION
This should be usefull i.e. when user use 'release' publish schema.
When no value is defined then values are getted from chart.yaml ( as previously ).
This makes no breacking change in API. Only extend ablilities.