### PR TITLE
Add option to prevent overriding releases.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ inputs:
   chart_version:
     description: "Set the version on the chart to this version"
     required: false
+  override_releases:
+    description: "If set to true will override already released chart versions"
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -63,3 +66,4 @@ runs:
     - ${{ inputs.commit_email }}
     - ${{ inputs.app_version }}
     - ${{ inputs.chart_version }}
+    - ${{ inputs.override_releases }}


### PR DESCRIPTION
Hi there!

Not sure if you're interested in this PR but at least I wanted to offer this to you.

I like this action a lot but it's important to me that already published charts will not be overwritten once published (references #13).

Unfortunately, my skills in Bash are limited but I tried my best and it looks like it's working already. :sweat_smile: 

Regards!