### PR TITLE
Enable GHE 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Inputs:
 * `app_version` Explicitly specify app version in package. If not defined then used chart values.
 * `chart_version` Explicitly specify chart version in package. If not defined then used chart values.
 * `index_dir` The location of `index.yaml` file in the repo, defaults to the same value as `target_dir`
+* `enterprise_url` The URL of enterprise github server in the format `<server-url>/<organisation>`
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,9 @@ inputs:
   index_dir:
     description: "The location of `index.yaml` file in the repo, defaults to the same value as `target_dir`"
     required: false
+  enterprise_url:
+    description: "The URL of enterprise github server in the format '<server-url>/<organisation>'"
+    required: false    
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -67,3 +70,4 @@ runs:
     - ${{ inputs.app_version }}
     - ${{ inputs.chart_version }}
     - ${{ inputs.index_dir }}
+    - ${{ inputs.enterprise_url }}

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -73,9 +73,9 @@ main() {
 
   if [[ -z "$REPO_URL" ]]; then
       if [[ -z "$ENTERPRISE_URL" ]]; then
-          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@${ENTERPRISE_URL}/${REPOSITORY}"
-      else 
           REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPOSITORY}"
+      else 
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@${ENTERPRISE_URL}/${REPOSITORY}"
       fi 
   fi
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -31,6 +31,7 @@ COMMIT_EMAIL=${11}
 APP_VERSION=${12}
 CHART_VERSION=${13}
 INDEX_DIR=${14}
+ENTERPRISE_URL=${15}
 
 CHARTS=()
 CHARTS_TMP_DIR=$(mktemp -d)
@@ -71,7 +72,11 @@ main() {
   fi
 
   if [[ -z "$REPO_URL" ]]; then
-      REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPOSITORY}"
+      if [[ -z "$ENTERPRISE_URL" ]]; then
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@${ENTERPRISE_URL}/${REPOSITORY}"
+      else 
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPOSITORY}"
+      fi 
   fi
 
   if [[ -z "$COMMIT_USERNAME" ]]; then


### PR DESCRIPTION
This PR enables the action to also be used on enterprise github servers.
A additional flag `enterprise_url` can be set which will the publish to the desired enterprise server