### PR TITLE
Allow helm private repos in the `dependencies` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Inputs:
 * `chart_version` Explicitly specify chart version in package. If not defined then used chart values.
 * `index_dir` The location of `index.yaml` file in the repo, defaults to the same value as `target_dir`
 * `enterprise_url` The URL of enterprise github server in the format `<server-url>/<organisation>`
-* `dependencies` A list of helm repositories required to verify dependencies in the format `<name>,<url>;<name>,<url>`
+* `dependencies` A list of helm repositories required to verify dependencies in the format `<name>,<url>;<name>,<url>` or if using private repositories `<name>,<username>,<password>,<url>;<name>,<username>,<password>,<url>`. Combinations are allowed.
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
   commit_username:
     description: "The user name used for the commit user"
     required: false
-    default: ${{ github.actor }} 
+    default: ${{ github.actor }}
   commit_email:
     description: "The email used for the commit user"
     required: false
@@ -54,7 +54,7 @@ inputs:
     required: false
   dependencies:
     description: "A list of helm repositories required to verify dependencies in the format '<name>,<url>;<name>,<url>'"
-    required: false     
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -75,9 +75,9 @@ main() {
   if [[ -z "$REPO_URL" ]]; then
       if [[ -z "$ENTERPRISE_URL" ]]; then
           REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPOSITORY}"
-      else 
+      else
           REPO_URL="https://x-access-token:${GITHUB_TOKEN}@${ENTERPRISE_URL}/${REPOSITORY}"
-      fi 
+      fi
   fi
 
   if [[ -z "$COMMIT_USERNAME" ]]; then
@@ -129,9 +129,18 @@ download() {
 get_dependencies() {
   IFS=';' read -ra dependency <<< "$DEPENDENCIES"
   for repos in ${dependency[@]}; do
-    name=$(cut -f 1 -d, <<< "$repos")
-    url=$(cut -f 2 -d, <<< "$repos")
-    helm repo add ${name} ${url}
+    result=$( echo $repos|awk -F',' '{print NF}' )
+    if [[ $result -gt 2 ]]; then
+      name=$(cut -f 1 -d, <<< "$repos")
+      username=$(cut -f 2 -d, <<< "$repos")
+      password=$(cut -f 3 -d, <<< "$repos")
+      url=$(cut -f 4 -d, <<< "$repos")
+      helm repo add ${name} --username ${username} --password ${password} ${url}
+    else
+      name=$(cut -f 1 -d, <<< "$repos")
+      url=$(cut -f 2 -d, <<< "$repos")
+      helm repo add ${name} ${url}
+    fi
   done
 }
 


### PR DESCRIPTION
We use this as a workaround for the issue mentioned in https://github.com/stefanprodan/helm-gh-pages/issues/31.

Password is passed from `${{ secrets.SOMETHING }}` variable.