### PR TITLE
Support packaging and pushing a specified chart only

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GitHub Action for publishing Helm charts with Github Pages.
 
 Inputs:
 * `token` The GitHub token with write access to the target repository
-* `charts_dir` The charts directory, defaults to `charts`
+* `charts_dir` The charts directory, defaults to `charts` (cannot be used if `chart_dir` is set)
 * `charts_url` The GitHub Pages URL, defaults to `https://<OWNER>.github.io/<REPOSITORY>`
 * `owner` The GitHub user or org that owns this repository, defaults to the owner in `GITHUB_REPOSITORY` env var
 * `repository` The GitHub repository, defaults to the `GITHUB_REPOSITORY` env var
@@ -21,6 +21,7 @@ Inputs:
 * `index_dir` The location of `index.yaml` file in the repo, defaults to the same value as `target_dir`
 * `enterprise_url` The URL of enterprise github server in the format `<server-url>/<organisation>`
 * `dependencies` A list of helm repositories required to verify dependencies in the format `<name>,<url>;<name>,<url>` or if using private repositories `<name>,<username>,<password>,<url>;<name>,<username>,<password>,<url>`. Combinations are allowed.
+* `chart_dir` The specified chart directory, e.g. charts/wordpress (cannot be used if `charts_dir` is set)
 
 ## Examples
 
@@ -87,4 +88,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           app_version: 1.16.0
           chart_version: 0.1.0
+```
+Package and push the specified chart in `./charts/wordpress` dir to `gh-pages` branch:
+```yaml
+name: release
+on:
+  push:
+    tags: '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          chart_dir: charts/wordpress
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "GitHub token"
     required: true
   charts_dir:
-    description: "The charts directory, defaults to `charts`"
+    description: "The charts directory, defaults to `charts` (cannot be used if `chart_dir` is set)"
     required: false
   charts_url:
     description: "The GitHub Pages URL, defaults to `https://<OWNER>.github.io/<REPOSITORY>`"
@@ -55,6 +55,9 @@ inputs:
   dependencies:
     description: "A list of helm repositories required to verify dependencies in the format '<name>,<url>;<name>,<url>'"
     required: false
+  chart_dir:
+    description: "The specified chart directory, e.g. charts/wordpress (cannot be used if `charts_dir` is set)"
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -75,3 +78,4 @@ runs:
     - ${{ inputs.index_dir }}
     - ${{ inputs.enterprise_url }}
     - ${{ inputs.dependencies }}
+    - ${{ inputs.chart_dir }}

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -33,6 +33,7 @@ CHART_VERSION=${13}
 INDEX_DIR=${14}
 ENTERPRISE_URL=${15}
 DEPENDENCIES=${16}
+CHART_DIR=${17}
 
 CHARTS=()
 CHARTS_TMP_DIR=$(mktemp -d)
@@ -40,6 +41,11 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 REPO_URL=""
 
 main() {
+  if [[ -n "$CHARTS_DIR" ]] && [[ -n "$CHART_DIR" ]]; then
+      echo '"Both charts_dir" and "chart_dir" cannot be set' >&2
+      exit 1
+  fi
+
   if [[ -z "$HELM_VERSION" ]]; then
       HELM_VERSION="3.10.0"
   fi
@@ -104,6 +110,12 @@ main() {
 }
 
 locate() {
+  if [[ -n "$CHART_DIR" ]]; then
+    echo "Use the specified chart directory ${CHART_DIR}"
+    CHARTS+=( "$CHART_DIR" )
+    return
+  fi
+
   for dir in $(find "${CHARTS_DIR}" -type d -mindepth 1 -maxdepth 1); do
     if [[ -f "${dir}/Chart.yaml" ]]; then
       CHARTS+=("${dir}")


### PR DESCRIPTION
This PR supports packaging and pushing a specified chart only.

I want to release a specified chart with a specified chartVersion in a repository containing multiple charts. For example, the workflow would be as follows.

```yaml
name: Release Charts

on:
  push:
    tags: ["**"]

jobs:
  release:
    runs-on: ubuntu-latest
    steps:
      - name: Get the chart name and version from the tag
        uses: actions/github-script@v6
        id: info
        with:
          script: |
            const tag = process.env.GITHUB_REF_NAME
            // The tag name is assumed to be `<chart name>-<chartVersion>`.
            const matches = tag.match(/^(.+)-([0-9]+\.[0-9]+\.[0-9]+)$/)
            console.log(matches)
            core.setOutput('name', matches[1])
            core.setOutput('version', matches[2])

      - name: Checkout
        uses: actions/checkout@v3

      - name: Publish Helm chart
        uses: stefanprodan/helm-gh-pages@master
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
          chart_dir: charts/${{steps.info.outputs.name}}
          chart_version: ${{steps.info.outputs.version}}
```