### PR TITLE
Support packaging chart in root directory

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -104,14 +104,19 @@ main() {
 }
 
 locate() {
-  for dir in $(find "${CHARTS_DIR}" -type d -mindepth 1 -maxdepth 1); do
-    if [[ -f "${dir}/Chart.yaml" ]]; then
-      CHARTS+=("${dir}")
-      echo "Found chart directory ${dir}"
-    else
-      echo "Ignoring non-chart directory ${dir}"
-    fi
-  done
+
+  if [[ "${CHARTS_DIR}" == "." ]]; then
+    echo "Chart directory set to repository root. Treating everything as part of the chart."
+    CHARTS+=(".")
+  else
+    for dir in $(find "${CHARTS_DIR}" -type d -mindepth 1 -maxdepth 1); do
+      if [[ -f "${dir}/Chart.yaml" ]]; then
+        CHARTS+=("${dir}")
+        echo "Found chart directory ${dir}"
+      else
+        echo "Ignoring non-chart directory ${dir}"
+      fi
+   done
 }
 
 download() {

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -104,7 +104,6 @@ main() {
 }
 
 locate() {
-
   if [[ "${CHARTS_DIR}" == "." ]]; then
     echo "Chart directory set to repository root. Treating everything as part of the chart."
     CHARTS+=(".")
@@ -116,7 +115,8 @@ locate() {
       else
         echo "Ignoring non-chart directory ${dir}"
       fi
-   done
+    done
+  fi
 }
 
 download() {


### PR DESCRIPTION
This allows for packaging a chart that is at the root of a repository (i.e. the only content of a repository).

Fixes #37 