### PR TITLE
fix: correct artifact url with missed index and custom target directory

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -179,6 +179,7 @@ upload() {
 
   charts=$(cd ${CHARTS_TMP_DIR} && ls *.tgz | xargs)
 
+  mkdir -p ${INDEX_DIR}
   mkdir -p ${TARGET_DIR}
 
   if [[ -f "${INDEX_DIR}/index.yaml" ]]; then
@@ -188,8 +189,9 @@ upload() {
     mv -f ${CHARTS_TMP_DIR}/index.yaml ${INDEX_DIR}/index.yaml
   else
     echo "No index found, generating a new one"
+    helm repo index ${CHARTS_TMP_DIR} --url ${CHARTS_URL}
     mv -f ${CHARTS_TMP_DIR}/*.tgz ${TARGET_DIR}
-    helm repo index ${INDEX_DIR} --url ${CHARTS_URL}
+    mv -f ${CHARTS_TMP_DIR}/index.yaml ${INDEX_DIR}
   fi
 
   git add ${TARGET_DIR}


### PR DESCRIPTION
When index is absent and custom target directory is used, the artifact url for the chart contains duplicated target dir, e.g. instead of `https://stefanprodan.github.com/helm-gh-pages/charts/chart-v1.2.3.tgz` -> `https://stefanprodan.github.com/helm-gh-pages/charts/charts/chart-v1.2.3.tgz`. This PR fixes this.